### PR TITLE
ch02-05_to_06: 리포지터리로 데이터베이스 관리하기 및 도메인별로 분류하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mysite/sbb/answer/Answer.java
+++ b/src/main/java/com/mysite/sbb/answer/Answer.java
@@ -1,5 +1,6 @@
-package com.mysite.sbb;
+package com.mysite.sbb.answer;
 
+import com.mysite.sbb.question.Question;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/mysite/sbb/answer/AnswerRepository.java
+++ b/src/main/java/com/mysite/sbb/answer/AnswerRepository.java
@@ -1,0 +1,7 @@
+package com.mysite.sbb.answer;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Integer> {
+
+}

--- a/src/main/java/com/mysite/sbb/question/Question.java
+++ b/src/main/java/com/mysite/sbb/question/Question.java
@@ -1,5 +1,6 @@
-package com.mysite.sbb;
+package com.mysite.sbb.question;
 
+import com.mysite.sbb.answer.Answer;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/mysite/sbb/question/QuestionRepository.java
+++ b/src/main/java/com/mysite/sbb/question/QuestionRepository.java
@@ -1,0 +1,11 @@
+package com.mysite.sbb.question;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuestionRepository extends JpaRepository<Question, Integer> {
+    Question findBySubject(String subject);
+    Question findBySubjectAndContent(String subject, String Content);
+    List<Question> findBySubjectLike(String subject);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,5 @@ spring.datasource.password=
 # JPA
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.show_sql=true

--- a/src/test/java/com/mysite/sbb/SbbApplicationTests.java
+++ b/src/test/java/com/mysite/sbb/SbbApplicationTests.java
@@ -1,13 +1,121 @@
 package com.mysite.sbb;
 
+import com.mysite.sbb.answer.AnswerRepository;
+import com.mysite.sbb.question.QuestionRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest // SbbApplicationTests 클래스가 스프링 부트의 테스트 클래스임을 의미함
 class SbbApplicationTests {
 
-    @Test
-    void contextLoads() {
+    @Autowired // 스프링의 의존성 주입(DI)을 사용하여 QuestionReppository의 객체를 주입함
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private AnswerRepository answerRepository;
+
+    // 의존성 주입이란, 스프링이 객체를 대신 생성하여 주입하는 기법을 말한다.
+
+    @Transactional // 메서드가 종료될 때까지 DB 세션이 유지됨 (질문 데이터를 통해 댭변 데이터 찾기에서 필요)
+    @Test // testJpa 메서드가 테스트 메서드임을 나타냄
+    void testJpa() {
+        /* TODO: 질문 데이터 저장하기
+        Question q1 = new Question();
+        q1.setSubject("sbb가 무엇인가요?");
+        q1.setContent("sbb에 대해서 알고 싶습니다.");
+        q1.setCreateDate(LocalDateTime.now());
+        this.questionReppository.save(q1);
+
+        Question q2 = new Question();
+        q2.setSubject("스프링 부트 모델 질문입니다.");
+        q2.setContent("id는 자동으로 생성되나요?");
+        q2.setCreateDate(LocalDateTime.now());
+        this.questionReppository.save(q2);
+         */
+
+        /* TODO: findAll 메서드
+        List<Question> all = this.questionReppository.findAll();
+        assertEquals(2, all.size());
+
+        Question q = all.get(0);
+        assertEquals("sbb가 무엇인가요?", q.getSubject());
+        */
+
+        /* TODO: findById 메서드
+        Optional<Question> oq = this.questionReppository.findById(1);
+        if (oq.isPresent()) { // isPresent() 메서드를 통해 값이 존재하는지부터 체크
+            Question q = oq.get(); // get() 메서드를 통해 실제 값 얻기
+            assertEquals("sbb가 무엇인가요?", q.getSubject());
+        }
+        */
+
+        /* TODO: findBySubject 메서드
+        Question q = this.questionRepository.findBySubject("sbb가 무엇인가요?");
+        assertEquals(1, q.getId());
+        */
+
+        /* TODO: findBySubjectAndContent 메서드
+        Question q = this.questionRepository.findBySubjectAndContent(
+                "sbb가 무엇인가요?", "sbb에 대해서 알고 싶습니다.");
+        assertEquals(1, q.getId());
+        */
+
+        /* TODO: findBySubjectLike 메서드
+        List<Question> qList = this.questionRepository.findBySubjectLike("sbb%");
+        Question q = qList.get(0);
+        assertEquals("sbb가 무엇인가요?", q.getSubject());
+        */
+
+        /* TODO: 질문 데이터 수정하기
+        Optional<Question> oq = this.questionRepository.findById(1);
+        assertTrue(oq.isPresent());
+        Question q = oq.get();
+        q.setSubject("수정된 제목");
+        this.questionRepository.save(q);
+        */
+
+        /* TODO: 질문 데이터 삭제하기
+        assertEquals(2, this.questionRepository.count());
+        Optional<Question> oq = this.questionRepository.findById(1);
+        assertTrue(oq.isPresent());
+        Question q = oq.get();
+        this.questionRepository.delete(q);
+        assertEquals(1, this.questionRepository.count());
+        */
+
+        /* TODO: 답변 데이터 저장하기
+        Optional<Question> oq = this.questionRepository.findById(2);
+        assertTrue(oq.isPresent());
+        Question q = oq.get();
+
+        Answer a = new Answer();
+        a.setContent("네 자동으로 생성됩니다.");
+        a.setQuestion(q);
+        a.setCreateDate(LocalDateTime.now());
+        this.answerRepository.save(a);
+        */
+
+        /* TODO: 답변 데이터 조회하기
+        Optional<Answer> oa = this.answerRepository.findById(1);
+        assertTrue(oa.isPresent());
+        Answer a = oa.get();
+        assertEquals(2, a.getQuestion().getId());
+        */
+
+        /* TODO: 답변 데이터를 통해 질문 데이터 찾기 vs 질문 데이터를 통해 댭변 데이터 찾기
+        Optional<Question> oq = this.questionRepository.findById(2);
+        assertTrue(oq.isPresent());
+        Question q = oq.get();
+
+        List<Answer> answerList = q.getAnswerList();
+        assertEquals(1, answerList.size());
+        assertEquals("네 자동으로 생성됩니다.", answerList.get(0).getContent());
+        */
     }
 
 }


### PR DESCRIPTION
## 1. 리포지토리 생성하기
- 기존에 만들었던 엔티티만으로는 데이터를 CRUD 할 수 없다.
- 따라서 데이터를 관리하려면 데이터베이스와 연동하는 JPA 리포지터리가 반드시 필요하다.
- 엔티티가 데이터베이스 테이블을 생성했다면
- 리포지터리는 생성된 데이터베이스 테이블의 데이터들을 저장, 조회, 수정, 삭제 등을 할 수 있도록 도와주는 인터페이스이다. 
  - 테이블에 접근한다. 
  - 데이터를 관리하는 메서드를 제공한다.

```java
public interface QuestionRepository extends JpaRepository<Question, Integer> { ... }
```

위 코드에서 `Question`과 `Integer`는 각각 다음과 같은 의미를 가진다.
- `Question`: `Question` 엔티티로 리포지토리를 생성할게요.
- `Integer`: 근데 이제 `Question`의 기본키가 `Integer`입니다.

## 2. `JpaRepository`란?
- JPA가 제공하는 인터페이스 중 하나이다.
- CRUD 작업을 처리하는 메서드들을 이미 내장하고 있어 데이터 관리 작업을 좀 더 편리하게 할 수 있다.

## 3. `JUnit` 설치하기
- 리포지터리를 이용하여 데이터를 저장하려면 컨트롤러, 서비스 파일 등이 필요하다.
- 하지만 `JUnit`을 사용하면 리포지터리만 개별적으로 실행해 테스트해 볼 수 있다. 

```java
testImplementation 'org.junit.jupiter:junit-jupiter'
testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
```

## 4. `@Autowired` 애너테이션
```java
@Autowired // 스프링의 의존성 주입(DI)을 사용하여 QuestionReppository의 객체를 주입함
private QuestionRepository questionRepository;

@Autowired
private AnswerRepository answerRepository;

// 의존성 주입이란, 스프링이 객체를 대신 생성하여 주입하는 기법을 말한다.
```
`@Autowired` 애너테이션을 변수에 적용하면 스프링 부트가 리포지토리 객체를 자동으로 만들어 주입한다.
객체를 주입하는 방식에는 다음의 2가지 방식이 존재한다.
- `@Autowired` 애너테이션을 사용하기
- `Setter` 메서드 또는 생성자를 사용하기

순환 참조 문제와 같은 이유로 개발 시 `@Autowired`보다는 생성자를 통한 객체 주입 방식을 권장한다.
하지만 테스트 코드의 경우 JUnit이 생성자를 통한 객체 주입을 지원하지 않는다.
따라서 다음과 같이 개발하는 것을 지향하자.

- 테스트 코드 작성 시에만 `@Autowired`를 사용하고 
- 실제 코드 작성 시에는 생성자를 통한 객체 주입 방식을 사용하자.

```
(주의) 로컬 서버가 이미 구동 중일 경우 
동일한 데이터베이스 파일을 점유하고 있기 때문에 테스트 코드를 실행할 때 오류가 발생한다. 
테스트 코드를 실행하고 싶다면 로컬 서버는 꼭 중지하자.
```

## 5. `findById`의 리턴 타입은 `Question`이 아닌 `Optional`이다
- `findById`로 호출된 값이 존재할 수도 있고, 존재하지 않을 수도 있어서 리턴 타입으로 `Optional`이 사용된 것이다.
- `Optional`: `null`값을 유연하게 처리하기 위한 클래스로, `isPresent()` 메서드로 값이 존재하는지 확인할 수 있다.

```java
Optional<Question> oq = this.questionReppository.findById(1);
if (oq.isPresent()) { // isPresent() 메서드를 통해 값이 존재하는지부터 체크
    Question q = oq.get(); // get() 메서드를 통해 실제 값 얻기
    assertEquals("sbb가 무엇인가요?", q.getSubject());
}
```

## 6. `findBySubject` 메서드가 구현 없이도 실행이 가능한 이유
- 인터페이스에 `findBySubject`라는 메서드를 선언만 하고 구현하지 않은 상황.
- JPA에 리포지터리의 메서드명을 분석하여 쿼리를 만들고 실행하는 기능이 있기 때문.
- `findBy + 엔티티의 속성명`과 같은 리포지터리의 메서드를 작성하면 입력한 속성의 값으로 데이터를 조회할 수 있다.

| SQL의 연산자     | 리포지터리의 메서드 예                                                                 | 설명                                                                 |
|------------------|--------------------------------------------------------------------------------------|----------------------------------------------------------------------|
| **And**          | `findBySubjectAndContent(String subject, String content)`                           | Subject, Content 열과 일치하는 데이터를 조회                         |
| **Or**           | `findBySubjectOrContent(String subject, String content)`                            | Subject 열 또는 Content 열과 일치하는 데이터를 조회                  |
| **Between**      | `findByCreateDateBetween(LocalDateTime fromDate, LocalDateTime toDate)`             | CreateDate 열의 데이터 중 정해진 범위 내에 있는 데이터를 조회        |
| **LessThan**     | `findByIdLessThan(Integer id)`                                                      | Id 열에서 조건보다 작은 데이터를 조회                                |
| **GreaterThanEqual** | `findByIdGreaterThanEqual(Integer id)`                                          | Id 열에서 조건보다 크거나 같은 데이터를 조회                         |
| **Like**         | `findBySubjectLike(String subject)`                                                 | Subject 열에서 문자열 ‘subject’와 같은 문자열을 포함한 데이터를 조회 |
| **In**           | `findBySubjectIn(String[] subjects)`                                                | Subject 열의 데이터가 주어진 배열에 포함되는 데이터만 조회            |
| **OrderBy**      | `findBySubjectOrderByCreateDateAsc(String subject)`                                 | Subject 열 조건에 일치하는 데이터를 조회 후 CreateDate 열을 오름차순으로 정렬 |

## 7. `@Transactional` 애너테이션이란?
- 실제 서버에서 JPA 프로그램들을 실행할 때는 DB 세션이 종료되지 않는다.
  - DB 세션이란 스프링 부트 애플리케이션과 데이터베이스 간의 연결을 뜻한다.
- 하지만 테스트 코드인 경우, 지연 방식으로 인해 DB 세션이 종료된 후 특정 작업이 수행될 때 오류가 발생할 수 있다.
- 이런 경우 `@Transactional` 애너테이션을 사용하여 해결할 수 있다.